### PR TITLE
Fix string interpolation in bot

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -228,7 +228,7 @@ async function sendForm(roomId, type) {
   await axios.post("https://webexapis.com/v1/messages",
     {
       roomId,
-      markdown: `📋 Please complete the **${type}** form:\`,
+      markdown: `📋 Please complete the **${type}** form:`,
       attachments: [{ contentType: "application/vnd.microsoft.card.adaptive", content: form }],
     },
     { headers: { Authorization: WEBEX_BOT_TOKEN } });


### PR DESCRIPTION
## Summary
- close template string in `sendForm`

## Testing
- `node -c bot.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f746c6954832c956082e3eadd07ba